### PR TITLE
[python-neutronclient]:Fix for neutron policy-list

### DIFF
--- a/neutronclient/v2_0/client.py
+++ b/neutronclient/v2_0/client.py
@@ -476,7 +476,7 @@ class Client(ClientBase):
                      'rbac_policies': 'rbac_policy',
                      'address_scopes': 'address_scope',
                      'qos_policies': 'qos_policy',
-                     'policies': 'policy',
+                     'policys': 'policy',
                      'bandwidth_limit_rules': 'bandwidth_limit_rule',
                      'rule_types': 'rule_type',
                      }


### PR DESCRIPTION
Modifying 'policies' in EXTED_PLURALS dict to 'policys' so that the
right functin i.e list_policys() gets called bu neutron.

Closes-Bug: #1700581